### PR TITLE
chore: Migrate from conductor-score to code-conductor

### DIFF
--- a/.github/workflows/conductor.yml
+++ b/.github/workflows/conductor.yml
@@ -95,7 +95,7 @@ jobs:
             const body = `
             ## 🎼 System Health Alert
 
-            The automated health check has detected critical issues with the Conductor-Score system.
+            The automated health check has detected critical issues with the Code Conductor system.
 
             ### Issues Detected
             - High number of stale agents

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
-name: 🎼 Release Conductor-Score
+name: 🎼 Release Code Conductor
 
 on:
   push:
@@ -49,11 +49,11 @@ jobs:
 
       - name: Create release archive
         run: |
-          # Create conductor-score template archive
+          # Create code-conductor template archive
           mkdir -p dist
 
           # Include core template files
-          tar -czf dist/conductor-score-template-${{ steps.version.outputs.version }}.tar.gz \
+          tar -czf dist/code-conductor-template-${{ steps.version.outputs.version }}.tar.gz \
             .conductor/ \
             examples/ \
             docs/ \
@@ -65,7 +65,7 @@ jobs:
             .gitignore
 
           # Create quick-start zip for GitHub releases
-          zip -r dist/conductor-score-${{ steps.version.outputs.version }}.zip \
+          zip -r dist/code-conductor-${{ steps.version.outputs.version }}.zip \
             .conductor/ \
             examples/ \
             docs/ \
@@ -99,7 +99,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.version.outputs.tag_name }}
-          release_name: 🎼 Conductor-Score ${{ steps.version.outputs.version }}
+          release_name: 🎼 Code Conductor ${{ steps.version.outputs.version }}
           body_path: release_notes.md
           draft: false
           prerelease: false
@@ -110,8 +110,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/conductor-score-template-${{ steps.version.outputs.version }}.tar.gz
-          asset_name: conductor-score-template-${{ steps.version.outputs.version }}.tar.gz
+          asset_path: dist/code-conductor-template-${{ steps.version.outputs.version }}.tar.gz
+          asset_name: code-conductor-template-${{ steps.version.outputs.version }}.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload quick-start zip
@@ -120,8 +120,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/conductor-score-${{ steps.version.outputs.version }}.zip
-          asset_name: conductor-score-${{ steps.version.outputs.version }}.zip
+          asset_path: dist/code-conductor-${{ steps.version.outputs.version }}.zip
+          asset_name: code-conductor-${{ steps.version.outputs.version }}.zip
           asset_content_type: application/zip
 
       - name: Update installation URLs
@@ -129,10 +129,10 @@ jobs:
           echo "🎉 Release ${{ steps.version.outputs.version }} created!"
           echo ""
           echo "📦 Assets:"
-          echo "- Template: conductor-score-template-${{ steps.version.outputs.version }}.tar.gz"
-          echo "- Quick-start: conductor-score-${{ steps.version.outputs.version }}.zip"
+          echo "- Template: code-conductor-template-${{ steps.version.outputs.version }}.tar.gz"
+          echo "- Quick-start: code-conductor-${{ steps.version.outputs.version }}.zip"
           echo ""
           echo "🚀 Installation:"
-          echo "curl -sSL https://github.com/ryanmac/conductor-score/releases/download/${{ steps.version.outputs.tag_name }}/install.sh | bash"
+          echo "curl -sSL https://github.com/ryanmac/code-conductor/releases/download/${{ steps.version.outputs.tag_name }}/install.sh | bash"
           echo ""
-          echo "📚 Documentation: https://github.com/ryanmac/conductor-score/blob/main/docs/USAGE.md" 
+          echo "📚 Documentation: https://github.com/ryanmac/code-conductor/blob/main/docs/USAGE.md" 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to Conductor-Score will be documented in this file.
+All notable changes to Code Conductor will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.1] - 2024-07-22
 
 ### Added
-- 🖥️ **Warp-Optimized Workflow**: Conductor-Score now detects Warp and can open each agent's worktree in an AI-powered terminal on macOS, Linux, or Windows
+- 🖥️ **Warp-Optimized Workflow**: Code Conductor now detects Warp and can open each agent's worktree in an AI-powered terminal on macOS, Linux, or Windows
 - 📱 Cross-platform terminal support with fallbacks (iTerm2, Kitty, Alacritty, Windows Terminal)
 - 🛠️ Enhanced `gtopen` and `gtwarp` commands in worktree helper
 - 📊 Storage footprint guidance and cleanup recommendations
@@ -81,7 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2024-07-22
 
 ### Added
-- 🎼 Initial release of Conductor-Score
+- 🎼 Initial release of Code Conductor
 - 🤖 Hybrid role system with default "dev" and specialized roles
 - 📋 GitHub Issues integration with `conductor:task` labels
 - 🔒 Conflict prevention via git worktrees and file locking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Conductor-Score is an AI agent coordination system designed to orchestrate multiple AI coding agents (like Claude Code, Conductor, Warp) working on the same codebase. It provides GitHub-native task management with automatic conflict prevention through git worktrees.
+Code Conductor is an AI agent coordination system designed to orchestrate multiple AI coding agents (like Claude Code, Conductor, Warp) working on the same codebase. It provides GitHub-native task management with automatic conflict prevention through git worktrees.
 
-**IMPORTANT**: This is a template repository. When you encounter Conductor-Score files in a project, they have been imported to enable automated agent coordination. Work autonomously based on the task specifications in `workflow-state.json` and the guidance in these files.
+**IMPORTANT**: This is a template repository. When you encounter Code Conductor files in a project, they have been imported to enable automated agent coordination. Work autonomously based on the task specifications in `workflow-state.json` and the guidance in these files.
 
 ## Key Development Commands
 
@@ -111,7 +111,7 @@ worktree_retention_days: number (default 7)
 
 ## Development Workflow
 
-When modifying conductor-score itself:
+When modifying code-conductor itself:
 
 1. Make changes in appropriate files:
    - Core scripts: `.conductor/scripts/`
@@ -137,7 +137,7 @@ When modifying conductor-score itself:
 
 ## Autonomous Operation Guidelines
 
-When working in a project with Conductor-Score:
+When working in a project with Code Conductor:
 
 1. **Check for tasks**: Run `python .conductor/scripts/generate-summary.py` to see available work
 2. **Claim a task**: Use `python .conductor/scripts/task-claim.py --role [your-role]`

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
-# Conductor-Score Development Makefile
+# Code Conductor Development Makefile
 
 .PHONY: help install demo validate clean test setup
 
 # Default target
 help: ## Show this help message
-	@echo "🎼 Conductor-Score Development Commands"
+	@echo "🎼 Code Conductor Development Commands"
 	@echo "======================================"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-install: ## Install conductor-score in current directory
-	@echo "🚀 Installing Conductor-Score..."
+install: ## Install code-conductor in current directory
+	@echo "🚀 Installing Code Conductor..."
 	@bash install.sh --auto
 
 demo: ## Create and run a full demo
-	@echo "🎬 Creating Conductor-Score Demo..."
+	@echo "🎬 Creating Code Conductor Demo..."
 	@echo "=================================="
 	@echo ""
 	@echo "📁 Setting up demo environment..."
@@ -26,7 +26,7 @@ demo: ## Create and run a full demo
 	@cd /tmp/conductor-demo && git commit -m "Initial commit"
 	@echo "✅ Demo repository created"
 	@echo ""
-	@echo "🎼 Installing conductor-score..."
+	@echo "🎼 Installing code-conductor..."
 	@cd /tmp/conductor-demo && cp -r $(PWD)/.conductor .
 	@cd /tmp/conductor-demo && cp -r $(PWD)/examples .conductor/
 	@cd /tmp/conductor-demo && cp $(PWD)/setup.py .
@@ -54,12 +54,12 @@ demo: ## Create and run a full demo
 	@echo ""
 	@echo "🧹 To clean up: rm -rf /tmp/conductor-demo"
 
-validate: ## Validate the conductor-score configuration
-	@echo "🔍 Validating Conductor-Score..."
+validate: ## Validate the code-conductor configuration
+	@echo "🔍 Validating Code Conductor..."
 	@python .conductor/scripts/validate-config.py
 
 test: ## Run all system tests
-	@echo "🧪 Running Conductor-Score Tests..."
+	@echo "🧪 Running Code Conductor Tests..."
 	@echo "=================================="
 	@echo ""
 	@echo "📋 Configuration validation..."
@@ -81,7 +81,7 @@ test: ## Run all system tests
 	@echo "🎉 All tests passed!"
 
 setup: ## Interactive setup for development
-	@echo "🔧 Conductor-Score Development Setup"
+	@echo "🔧 Code Conductor Development Setup"
 	@echo "===================================="
 	@python setup.py
 
@@ -96,11 +96,11 @@ clean: ## Clean up generated files and caches
 	@echo "✅ Cleanup complete"
 
 quick-start: ## Show quick start instructions
-	@echo "🎼 Conductor-Score Quick Start"
+	@echo "🎼 Code Conductor Quick Start"
 	@echo "============================="
 	@echo ""
 	@echo "1. Install in your project:"
-	@echo "   curl -sSL https://github.com/ryanmac/conductor-score/raw/main/install.sh | bash"
+	@echo "   curl -sSL https://github.com/ryanmac/code-conductor/raw/main/install.sh | bash"
 	@echo ""
 	@echo "2. Create a task via GitHub issue with 'conductor:task' label"
 	@echo ""
@@ -113,7 +113,7 @@ quick-start: ## Show quick start instructions
 
 dev-aliases: ## Install helpful development aliases
 	@echo "🛠️  Installing development aliases..."
-	@echo "# Conductor-Score Development Aliases" >> ~/.bashrc
+	@echo "# Code Conductor Development Aliases" >> ~/.bashrc
 	@echo "alias ctr='cd worktrees && ls'" >> ~/.bashrc
 	@echo "alias cth='python .conductor/scripts/health-check.py'" >> ~/.bashrc
 	@echo "alias cts='python .conductor/scripts/update-status.py'" >> ~/.bashrc
@@ -123,5 +123,5 @@ dev-aliases: ## Install helpful development aliases
 	@echo "Run 'source ~/.bashrc' to load them"
 
 version: ## Show version information
-	@echo "🎼 Conductor-Score v$$(cat VERSION)"
+	@echo "🎼 Code Conductor v$$(cat VERSION)"
 	@echo "📅 Release: $$(head -1 CHANGELOG.md | grep -o '\[.*\]' | tr -d '[]')" 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# 🎼 Conductor's Score
+# 🎼 Code Conductor
+
+> ⚠️ **Repository Renamed**  
+> This project was previously named **Conductor's Score** (`conductor-score`).  
+> It has been renamed to **Code Conductor** (`code-conductor`) as of July 23, 2025.  
+> GitHub redirects all URLs, but please update any bookmarks or references.
 
 <img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/09dea359-56a0-4c65-8c16-b98ec2b4f02a" />
 
@@ -19,7 +24,7 @@
 
 ## 🎯 **90% Stack Coverage - Your Tech is Supported**
 
-Conductor-Score automatically detects and configures for the most popular technology stacks:
+Code Conductor automatically detects and configures for the most popular technology stacks:
 
 ### **Frontend & Full-Stack** (40% of projects)
 - **React/Next.js** - Auto-configures frontend & UI roles
@@ -58,13 +63,13 @@ Based on your stack, we automatically add:
 **Prerequisites for all options:** Git, Python 3.9-3.12, curl (for one-liner), and tar. Run from the root of an existing Git repository. **If using pyenv, ensure your active Python version (e.g., via `pyenv shell 3.12.x`) has Poetry installed if you prefer it; otherwise, the script falls back to pip.**
 
 ### **Option 1: Universal One-Liner (Recommended - No Cloning Required)**
-Run this in your existing project's root directory to download and install Conductor-Score directly:
+Run this in your existing project's root directory to download and install Code Conductor directly:
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/ryanmac/conductor-score/main/conductor-init.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/ryanmac/code-conductor/main/conductor-init.sh)
 ```
 
-- This method avoids cloning the full Conductor-Score repo and is ideal for integrating into existing projects without repository pollution.
+- This method avoids cloning the full Code Conductor repo and is ideal for integrating into existing projects without repository pollution.
 - The script will prompt before overwriting any existing installation.
 - **Security best practice:** Review the script at the raw URL before running.
 - **Pyenv users:** If Poetry install fails, switch to the Python version that has Poetry installed (e.g., `pyenv shell 3.10.13`) and re-run.
@@ -76,8 +81,8 @@ bash <(curl -fsSL https://raw.githubusercontent.com/ryanmac/conductor-score/main
 ### Option 2: Poetry (For Cloned Repo)
 ```bash
 # Clone the repository
-git clone https://github.com/ryanmac/conductor-score.git
-cd conductor-score
+git clone https://github.com/ryanmac/code-conductor.git
+cd code-conductor
 
 # Install with Poetry (auto-creates virtual environment)
 poetry install
@@ -87,8 +92,8 @@ poetry run python setup.py
 ### Option 3: Pip + Virtual Environment (For Cloned Repo)
 ```bash
 # Clone the repository
-git clone https://github.com/ryanmac/conductor-score.git
-cd conductor-score
+git clone https://github.com/ryanmac/code-conductor.git
+cd code-conductor
 
 # Create virtual environment
 python3 -m venv .venv
@@ -258,7 +263,7 @@ cd worktrees/agent-dev-[task_id]
 The system provides a single prompt that works for any agent:
 
 ```
-You are a Claude Code agent in a conductor-score coordinated project.
+You are a Claude Code agent in a Code Conductor coordinated project.
 ROLE: {role}
 PROJECT: {project_name}
 
@@ -425,8 +430,8 @@ python .conductor/scripts/validate-config.py
 ### Local Development
 ```bash
 # Clone and setup
-git clone https://github.com/ryanmac/conductor-score.git
-cd conductor-score
+git clone https://github.com/ryanmac/code-conductor.git
+cd code-conductor
 
 # Install with Poetry (recommended)
 poetry install
@@ -474,15 +479,15 @@ MIT - See LICENSE file
 
 ## Support
 
-- 🐛 [Issue Tracker](https://github.com/ryanmac/conductor-score/issues)
-- 💬 [Discussions](https://github.com/ryanmac/conductor-score/discussions)
+- 🐛 [Issue Tracker](https://github.com/ryanmac/code-conductor/issues)
+- 💬 [Discussions](https://github.com/ryanmac/code-conductor/discussions)
 
 ## 💬 **Join the Community**
 
-- 🐛 **Found a bug?** [Report it](https://github.com/ryanmac/conductor-score/issues)
-- 💡 **Have an idea?** [Start a discussion](https://github.com/ryanmac/conductor-score/discussions)
+- 🐛 **Found a bug?** [Report it](https://github.com/ryanmac/code-conductor/issues)
+- 💡 **Have an idea?** [Start a discussion](https://github.com/ryanmac/code-conductor/discussions)
 - 🛠️ **Want to contribute?** [See our guide](CONTRIBUTING.md)
-- 𝕏 **Share your success** Mention [@ryanmac](https://x.com/ryanmac) with #ConductorScore
+- 𝕏 **Share your success** Mention [@ryanmac](https://x.com/ryanmac) with #CodeConductor
 
 **Built for [Conductor.build](https://conductor.build) and [Warp](https://www.warp.dev/) users who refuse to juggle tasks manually.**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,14 +10,14 @@ Use this section to tell people about which versions of your project are current
 
 ## Reporting a Vulnerability
 
-We take security vulnerabilities seriously. If you discover a security vulnerability in Conductor-Score, please follow these steps:
+We take security vulnerabilities seriously. If you discover a security vulnerability in Code Conductor, please follow these steps:
 
 ### 1. **DO NOT** create a public GitHub issue
 Security vulnerabilities should be reported privately to prevent potential exploitation.
 
 ### 2. Email the maintainer
 Send an email to the maintainer with the following information:
-- **Subject:** `[SECURITY] Conductor-Score Vulnerability Report`
+- **Subject:** `[SECURITY] Code Conductor Vulnerability Report`
 - **Description:** Detailed description of the vulnerability
 - **Steps to reproduce:** Clear steps to reproduce the issue
 - **Impact:** Potential impact of the vulnerability
@@ -35,7 +35,7 @@ Send an email to the maintainer with the following information:
 
 ## Security Best Practices
 
-When using Conductor-Score:
+When using Code Conductor:
 
 1. **Keep dependencies updated:** Regularly update your dependencies to get security patches
 2. **Review configurations:** Ensure your `.conductor/config.yaml` doesn't expose sensitive information

--- a/conductor-init.sh
+++ b/conductor-init.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# conductor-init.sh - Universal Installer for Conductor-Score
-# Usage: bash <(curl -fsSL https://raw.githubusercontent.com/ryanmac/conductor-score/main/conductor-init.sh)
-# Installs Conductor-Score into the current Git repository without full cloning.
+# conductor-init.sh - Universal Installer for Code Conductor
+# Usage: bash <(curl -fsSL https://raw.githubusercontent.com/ryanmac/code-conductor/main/conductor-init.sh)
+# Installs Code Conductor into the current Git repository without full cloning.
 
 set -e
 
@@ -12,9 +12,9 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-echo -e "${GREEN}🚀 Conductor-Score Universal Installer${NC}"
+echo -e "${GREEN}🚀 Code Conductor Universal Installer${NC}"
 echo "=========================================="
-echo "This script will install Conductor-Score into your current Git repository."
+echo "This script will install Code Conductor into your current Git repository."
 echo "It will download necessary files and run the setup automatically."
 echo ""
 
@@ -73,8 +73,8 @@ echo ""
 
 # Step 2: Download and Extract Essential Files from Tarball
 echo -e "${YELLOW}📥 Downloading and extracting from GitHub tarball...${NC}"
-REPO_TARBALL_URL="https://github.com/ryanmac/conductor-score/archive/refs/heads/main.tar.gz"
-TEMP_DIR="/tmp/conductor-score-init"
+REPO_TARBALL_URL="https://github.com/ryanmac/code-conductor/archive/refs/heads/main.tar.gz"
+TEMP_DIR="/tmp/code-conductor-init"
 
 # Create temp dir
 mkdir -p "$TEMP_DIR"
@@ -193,7 +193,7 @@ else
     read -p "Commit these changes automatically? [Y/n]: " -n 1 -r
     echo ""
     if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
-        git commit -m "Initialize Conductor-Score setup" || echo -e "${YELLOW}⚠️ Commit failed.${NC}"
+        git commit -m "Initialize Code Conductor setup" || echo -e "${YELLOW}⚠️ Commit failed.${NC}"
         echo -e "${GREEN}✅ Changes committed.${NC}"
     else
         echo -e "${YELLOW}⚠️ Skipping commit. Remember to commit manually.${NC}"
@@ -400,7 +400,7 @@ fi
 echo ""
 echo -e "${GREEN}🎉 Installation Successful!${NC}"
 echo "=========================================="
-echo "Conductor-Score is now installed with:"
+echo "Code Conductor is now installed with:"
 if [ -n "$DETECTED_STACKS" ]; then
     echo "  ✅ Auto-detected: $DETECTED_STACKS"
 else
@@ -418,7 +418,7 @@ echo "  🔧 Adjust config:  ${GREEN}$EDITOR .conductor/config.yaml${NC}"
 echo ""
 echo "${YELLOW}Your first PR will automatically get AI code reviews!${NC}"
 echo ""
-echo "📚 Documentation: https://github.com/ryanmac/conductor-score"
-echo "🐛 Report issues: https://github.com/ryanmac/conductor-score/issues"
+echo "📚 Documentation: https://github.com/ryanmac/code-conductor"
+echo "🐛 Report issues: https://github.com/ryanmac/code-conductor/issues"
 echo ""
 echo -e "${GREEN}Happy orchestrating! 🎼${NC}"

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
-# 🎼 Conductor-Score Usage Guide
+# 🎼 Code Conductor Usage Guide
 
-This guide shows you two ways to use Conductor-Score: with the Conductor desktop app (macOS only) or manually with multiple terminals (all platforms).
+This guide shows you two ways to use Code Conductor: with the Conductor desktop app (macOS only) or manually with multiple terminals (all platforms).
 
 ## 🖥️ **Recommended Terminals**
 
@@ -23,7 +23,7 @@ The Conductor app provides a streamlined experience with integrated AI sessions 
 
 ### Prerequisites
 - [Conductor Desktop App](https://conductor.build) installed
-- Git repository with Conductor-Score installed
+- Git repository with Code Conductor installed
 
 ### Step-by-Step Workflow
 
@@ -324,8 +324,8 @@ open -a Conductor
 - **Validate setup**: `python .conductor/scripts/validate-config.py`
 - **Check dependencies**: `python .conductor/scripts/dependency-check.py`
 - **System health**: `python .conductor/scripts/health-check.py`
-- **GitHub issues**: [Report bugs](https://github.com/ryanmac/conductor-score/issues)
-- **Discussions**: [Ask questions](https://github.com/ryanmac/conductor-score/discussions)
+- **GitHub issues**: [Report bugs](https://github.com/ryanmac/code-conductor/issues)
+- **Discussions**: [Ask questions](https://github.com/ryanmac/code-conductor/discussions)
 
 ---
 

--- a/docs/worktree-helper.sh
+++ b/docs/worktree-helper.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Conductor-Score Worktree Helper
+# Code Conductor Worktree Helper
 # Source this file for convenient worktree management aliases
 
 # Terminal detection and opening functions
@@ -108,7 +108,7 @@ gtclean() {
 }
 
 # Print available commands when sourced
-echo "🎼 Conductor-Score Worktree Helper Loaded"
+echo "🎼 Code Conductor Worktree Helper Loaded"
 echo ""
 echo "Available commands:"
 echo "  gtr <task_id>  - Switch to task worktree"

--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-# Conductor-Score Install Script
-# One-command setup for conductor-score
+# Code Conductor Install Script
+# One-command setup for code-conductor
 
 set -e
 
-echo "🚀 Setting up Conductor-Score..."
+echo "🚀 Setting up Code Conductor..."
 
 # Check if we're in the right directory
 if [ ! -f "setup.py" ]; then
-    echo "❌ Error: setup.py not found. Please run this script from the conductor-score directory."
+    echo "❌ Error: setup.py not found. Please run this script from the code-conductor directory."
     exit 1
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [tool.poetry]
-name = "conductor-score"
+name = "code-conductor"
 version = "0.1.0"
 description = "Agent coordination for Conductor, Warp, and Claude Code"
 authors = ["Ryan Mac <ryan@updoot.co>"]
 readme = "README.md"
-packages = [{include = "conductor_score"}]
+packages = [{include = "code_conductor"}]
 
 [tool.poetry.dependencies]
 python = "^3.9,<3.13"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Core dependencies for conductor-score
+# Core dependencies for code-conductor
 pyyaml>=6.0
 requests>=2.32.4
 # Note: fcntl is Unix-only and part of Python standard library 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Conductor Score Interactive Setup Script
+Code Conductor Interactive Setup Script
 Configures the repository for your specific project needs
 """
 
@@ -51,7 +51,7 @@ class ConductorSetup:
 
     def print_header(self):
         """Display setup header"""
-        print("🚀 Conductor Score Setup")
+        print("🚀 Code Conductor Setup")
         print("=" * 50)
         print("This will configure agent coordination for your project")
         print()
@@ -1391,7 +1391,7 @@ if __name__ == "__main__":
     def display_completion_message(self):
         """Show completion message and next steps"""
         print("\n" + "=" * 50)
-        print("🎉 Conductor Score Setup Complete!")
+        print("🎉 Code Conductor Setup Complete!")
         print("=" * 50)
 
         print("\n📋 Next Steps:")
@@ -1414,12 +1414,12 @@ if __name__ == "__main__":
         print("  - Configuration: .conductor/config.yaml")
         print("  - Scripts: .conductor/scripts/")
 
-        print("\n🚀 Happy coding with Conductor Score!")
+        print("\n🚀 Happy coding with Code Conductor!")
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Conductor Score Interactive Setup",
+        description="Code Conductor Interactive Setup",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-# Tests package for conductor-score
+# Tests package for code-conductor

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,4 @@
-"""Basic tests for conductor-score"""
+"""Basic tests for code-conductor"""
 
 import sys
 import yaml


### PR DESCRIPTION
## Summary
- Renamed all references from "conductor-score" to "code-conductor" throughout the codebase
- Added repository rename notice to README.md
- Updated all GitHub URLs to use the new repository name

## Changes Made
- ✅ Updated branding in README.md and documentation
- ✅ Changed all occurrences of "Conductor-Score" to "Code Conductor"
- ✅ Updated repository URLs from `conductor-score` to `code-conductor`
- ✅ Modified package name in pyproject.toml
- ✅ Updated GitHub Actions workflows
- ✅ Added rename notice for users

## Next Steps After Merge
1. Rename the GitHub repository from "conductor-score" to "code-conductor" in Settings
2. Update local git remotes to point to the new URL
3. GitHub will automatically redirect old URLs to the new repository

🤖 Generated with [Claude Code](https://claude.ai/code)